### PR TITLE
Enforce file naming convention for changelogs

### DIFF
--- a/.idea/updraft.iml
+++ b/.idea/updraft.iml
@@ -3,12 +3,7 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <excludePattern pattern=".cache" />
-      <excludePattern pattern=".yarn" />
       <excludePattern pattern="dist" />
-      <excludePattern pattern=".pnp.*" />
-      <excludePattern pattern="README.md" />
-      <excludePattern pattern="yarn.lock" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 ### Added
-- Support for Markdown changelogs in [Keep a Changelog](https://keepachangelog.com/en/1.1.0) format.
+- Support for Markdown changelogs
+  in [Keep a Changelog](https://keepachangelog.com/en/1.1.0) format.
 
 ### Changed
 - Add a trailing newline character in the output files.
+- Changelog files must be named `CHANGELOG.md` or `CHANGELOG.adoc`. Support for
+  other filenames has been deprecated and will be removed in the next major
+  release.
 - Normalise blank lines in changelogs.
 
 ## [1.0.0] - 2023-12-08
@@ -22,7 +26,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - New option: `--help`.
 - New option: `--release-version`.
 - New option: `--version`.
-- Support for AsciiDoc changelogs in [Keep a Changelog](https://keepachangelog.com/en/1.1.0) format.
+- Support for AsciiDoc changelogs
+  in [Keep a Changelog](https://keepachangelog.com/en/1.1.0) format.
 - Support for package.json files.
 
 [unreleased]: https://github.com/rainstormy/updraft/compare/v1.0.0...HEAD

--- a/src/program/PromotionProgram/PromotionProgram.testdata.ts
+++ b/src/program/PromotionProgram/PromotionProgram.testdata.ts
@@ -2,16 +2,12 @@ import type { File } from "+adapters/FileSystem/File"
 import type { Release } from "+utilities/Release"
 import { dedent } from "+utilities/StringUtilities"
 
-export type PromotionProgramDummies = {
+export function getAsciidocChangelogDummies(release: Release): {
 	emptyFile: File
 	nonPromotableFile: File
 	promotableFiles: [File, File, File, File]
 	expectedPromotedFiles: [File, File, File, File]
-}
-
-export function getAsciidocChangelogDummies(
-	release: Release,
-): PromotionProgramDummies {
+} {
 	return {
 		emptyFile: {
 			path: "CHANGELOG.adoc",
@@ -63,7 +59,7 @@ export function getAsciidocChangelogDummies(
 				`,
 			},
 			{
-				path: "packages/oranges/RELEASES.adoc",
+				path: "packages/oranges/CHANGELOG.adoc",
 				content: dedent`
 					= Releases
 
@@ -132,7 +128,7 @@ export function getAsciidocChangelogDummies(
 				`}\n`,
 			},
 			{
-				path: "packages/oranges/RELEASES.adoc",
+				path: "packages/oranges/CHANGELOG.adoc",
 				content: `${dedent`
 					= Releases
 
@@ -171,9 +167,12 @@ export function getAsciidocChangelogDummies(
 	}
 }
 
-export function getMarkdownChangelogDummies(
-	release: Release,
-): PromotionProgramDummies {
+export function getMarkdownChangelogDummies(release: Release): {
+	emptyFile: File
+	nonPromotableFile: File
+	promotableFiles: [File, File, File, File]
+	expectedPromotedFiles: [File, File, File, File]
+} {
 	return {
 		emptyFile: {
 			path: "CHANGELOG.md",
@@ -225,7 +224,7 @@ export function getMarkdownChangelogDummies(
 				`,
 			},
 			{
-				path: "packages/oranges/RELEASES.md",
+				path: "packages/oranges/CHANGELOG.md",
 				content: dedent`
 					# Releases
 
@@ -294,7 +293,7 @@ export function getMarkdownChangelogDummies(
 				`}\n`,
 			},
 			{
-				path: "packages/oranges/RELEASES.md",
+				path: "packages/oranges/CHANGELOG.md",
 				content: `${dedent`
 					# Releases
 
@@ -333,9 +332,12 @@ export function getMarkdownChangelogDummies(
 	}
 }
 
-export function getPackageJsonDummies(
-	release: Release,
-): PromotionProgramDummies {
+export function getPackageJsonDummies(release: Release): {
+	emptyFile: File
+	nonPromotableFile: File
+	promotableFiles: [File, File, File, File]
+	expectedPromotedFiles: [File, File, File, File]
+} {
 	return {
 		emptyFile: {
 			path: "package.json",
@@ -445,6 +447,98 @@ export function getPackageJsonDummies(
 						"name": "@rainstormy/peaches",
 						"version": "${release.version}"
 					}
+				`}\n`,
+			},
+		],
+	}
+}
+
+export function getDeprecatedDummies(release: Release): {
+	promotableFiles: [File, File]
+	expectedPromotedFiles: [File, File]
+} {
+	return {
+		promotableFiles: [
+			{
+				path: "RELEASES.adoc",
+				content: dedent`
+					= Changelog
+					:experimental:
+					:source-highlighter: highlight.js
+
+					This file documents all notable changes to this project.
+					The format is based on https://keepachangelog.com/en/1.1.0[Keep a Changelog], and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Versioning].
+
+					== {url-repo}/compare/v2.0.0-rc.1\\...HEAD[Unreleased]
+					=== Changed
+					* The fruit basket is now refilled every day.
+
+					== {url-repo}/releases/tag/v2.0.0-rc.1[2.0.0-rc.1] - 2023-12-03
+					=== Added
+					* A new shiny fruit basket.
+				`,
+			},
+			{
+				path: "HISTORY.md",
+				content: dedent`
+					# Changelog
+					This file documents all notable changes to this project.
+
+					The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0),
+					and this project adheres
+					to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+					## [Unreleased](https://github.com/rainstormy-actions/release/compare/v2.0.0-rc.1...HEAD)
+					### Changed
+					- The fruit basket is now refilled every day.
+
+					## [2.0.0-rc.1](https://github.com/rainstormy-actions/release/releases/tag/v2.0.0-rc.1) - 2023-12-03
+					### Added
+					- A new shiny fruit basket.
+				`,
+			},
+		],
+		expectedPromotedFiles: [
+			{
+				path: "RELEASES.adoc",
+				content: `${dedent`
+					= Changelog
+					:experimental:
+					:source-highlighter: highlight.js
+
+					This file documents all notable changes to this project.
+					The format is based on https://keepachangelog.com/en/1.1.0[Keep a Changelog], and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Versioning].
+
+					== {url-repo}/compare/v${release.version}\\...HEAD[Unreleased]
+
+					== {url-repo}/compare/v2.0.0-rc.1\\...v${release.version}[${release.version}] - ${release.date}
+					=== Changed
+					* The fruit basket is now refilled every day.
+
+					== {url-repo}/releases/tag/v2.0.0-rc.1[2.0.0-rc.1] - 2023-12-03
+					=== Added
+					* A new shiny fruit basket.
+				`}\n`,
+			},
+			{
+				path: "HISTORY.md",
+				content: `${dedent`
+					# Changelog
+					This file documents all notable changes to this project.
+
+					The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0),
+					and this project adheres
+					to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+					## [Unreleased](https://github.com/rainstormy-actions/release/compare/v${release.version}...HEAD)
+
+					## [${release.version}](https://github.com/rainstormy-actions/release/compare/v2.0.0-rc.1...v${release.version}) - ${release.date}
+					### Changed
+					- The fruit basket is now refilled every day.
+
+					## [2.0.0-rc.1](https://github.com/rainstormy-actions/release/releases/tag/v2.0.0-rc.1) - 2023-12-03
+					### Added
+					- A new shiny fruit basket.
 				`}\n`,
 			},
 		],

--- a/src/program/PromotionProgram/PromotionProgram.tests.ts
+++ b/src/program/PromotionProgram/PromotionProgram.tests.ts
@@ -4,6 +4,7 @@ import { injectTodayMock } from "+adapters/Today/Today.mock"
 import { mainProgram } from "+program/Program"
 import {
 	getAsciidocChangelogDummies,
+	getDeprecatedDummies,
 	getMarkdownChangelogDummies,
 	getPackageJsonDummies,
 	getUnsupportedDummies,
@@ -58,6 +59,17 @@ describe.each`
 			expectedPromotedFiles: expectedPromotedPackageJsonFiles,
 		} = getPackageJsonDummies(release)
 
+		const {
+			promotableFiles: [
+				promotableDeprecatedAsciidocChangelog,
+				promotableDeprecatedMarkdownChangelog,
+			],
+			expectedPromotedFiles: [
+				expectedPromotedDeprecatedAsciidocChangelog,
+				expectedPromotedDeprecatedMarkdownChangelog,
+			],
+		} = getDeprecatedDummies(release)
+
 		const unsupportedFiles = getUnsupportedDummies()
 
 		const args = [
@@ -87,6 +99,8 @@ describe.each`
 			const expectedWarning = `${filePatternList} did not match any files.`
 
 			it(`displays a warning that says '${expectedWarning}'`, () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printError).not.toHaveBeenCalled()
 				expect(printWarning).toHaveBeenCalledWith(expectedWarning)
 				expect(printWarning).toHaveBeenCalledTimes(1)
 			})
@@ -109,6 +123,8 @@ describe.each`
 			})
 
 			it("displays an error", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenCalledWith(
 					`${emptyAsciidocChangelog.path} must have an 'Unreleased' section.`,
 				)
@@ -133,6 +149,8 @@ describe.each`
 			})
 
 			it("displays an error", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenCalledWith(
 					`${nonPromotableAsciidocChangelog.path} must have at least one item in the 'Unreleased' section.`,
 				)
@@ -159,6 +177,8 @@ describe.each`
 			})
 
 			it("displays an error", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenCalledWith(
 					`${nonPromotableAsciidocChangelog.path} must have at least one item in the 'Unreleased' section.`,
 				)
@@ -185,6 +205,8 @@ describe.each`
 			})
 
 			it("displays two errors", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenNthCalledWith(
 					1,
 					`${emptyAsciidocChangelog.path} must have an 'Unreleased' section.`,
@@ -270,6 +292,8 @@ describe.each`
 			})
 
 			it("displays an error", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenCalledWith(
 					`${emptyMarkdownChangelog.path} must have an 'Unreleased' section.`,
 				)
@@ -294,6 +318,8 @@ describe.each`
 			})
 
 			it("displays an error", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenCalledWith(
 					`${nonPromotableMarkdownChangelog.path} must have at least one item in the 'Unreleased' section.`,
 				)
@@ -320,6 +346,8 @@ describe.each`
 			})
 
 			it("displays an error", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenCalledWith(
 					`${nonPromotableMarkdownChangelog.path} must have at least one item in the 'Unreleased' section.`,
 				)
@@ -346,6 +374,8 @@ describe.each`
 			})
 
 			it("displays two errors", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenNthCalledWith(
 					1,
 					`${emptyMarkdownChangelog.path} must have an 'Unreleased' section.`,
@@ -429,6 +459,8 @@ describe.each`
 			})
 
 			it("displays an error", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenCalledWith(
 					`${emptyPackageJsonFile.path} must have a 'version' field.`,
 				)
@@ -453,6 +485,8 @@ describe.each`
 			})
 
 			it("displays an error", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenCalledWith(
 					`${nonPromotablePackageJsonFile.path} must have a 'version' field.`,
 				)
@@ -479,6 +513,8 @@ describe.each`
 			})
 
 			it("displays an error", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenCalledWith(
 					`${nonPromotablePackageJsonFile.path} must have a 'version' field.`,
 				)
@@ -505,6 +541,8 @@ describe.each`
 			})
 
 			it("displays two errors", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenNthCalledWith(
 					1,
 					`${emptyPackageJsonFile.path} must have a 'version' field.`,
@@ -592,6 +630,8 @@ describe.each`
 			})
 
 			it("displays three errors", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenNthCalledWith(
 					1,
 					`${nonPromotableAsciidocChangelog.path} must have at least one item in the 'Unreleased' section.`,
@@ -627,6 +667,8 @@ describe.each`
 			})
 
 			it("displays an error", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenCalledWith(
 					`${nonPromotableAsciidocChangelog.path} must have at least one item in the 'Unreleased' section.`,
 				)
@@ -653,6 +695,8 @@ describe.each`
 			})
 
 			it("displays an error", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenCalledWith(
 					`${nonPromotableMarkdownChangelog.path} must have at least one item in the 'Unreleased' section.`,
 				)
@@ -679,6 +723,8 @@ describe.each`
 			})
 
 			it("displays an error", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenCalledWith(
 					`${nonPromotablePackageJsonFile.path} must have a 'version' field.`,
 				)
@@ -720,6 +766,106 @@ describe.each`
 			})
 		})
 
+		describe("and the only matching AsciiDoc changelog file is deprecated", () => {
+			beforeEach(async () => {
+				readMatchingFiles.mockImplementation(async () => [
+					promotableDeprecatedAsciidocChangelog,
+				])
+				actualExitCode = await mainProgram(args)
+			})
+
+			it("returns an exit code of 0", () => {
+				expect(actualExitCode).toBe(0)
+			})
+
+			it("displays a warning", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printError).not.toHaveBeenCalled()
+				expect(printWarning).toHaveBeenCalledWith(
+					`${promotableDeprecatedAsciidocChangelog.path} is not a supported filename and must be renamed to 'CHANGELOG.adoc' in Updraft v2.0.0.`,
+				)
+				expect(printWarning).toHaveBeenCalledTimes(1)
+			})
+
+			it("saves the promoted file", () => {
+				expect(writeFiles).toHaveBeenCalledWith([
+					expectedPromotedDeprecatedAsciidocChangelog,
+				])
+				expect(writeFiles).toHaveBeenCalledTimes(1)
+			})
+		})
+
+		describe("and the only matching Markdown changelog file is deprecated", () => {
+			beforeEach(async () => {
+				readMatchingFiles.mockImplementation(async () => [
+					promotableDeprecatedMarkdownChangelog,
+				])
+				actualExitCode = await mainProgram(args)
+			})
+
+			it("returns an exit code of 0", () => {
+				expect(actualExitCode).toBe(0)
+			})
+
+			it("displays a warning", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printError).not.toHaveBeenCalled()
+				expect(printWarning).toHaveBeenCalledWith(
+					`${promotableDeprecatedMarkdownChangelog.path} is not a supported filename and must be renamed to 'CHANGELOG.md' in Updraft v2.0.0.`,
+				)
+				expect(printWarning).toHaveBeenCalledTimes(1)
+			})
+
+			it("saves the promoted file", () => {
+				expect(writeFiles).toHaveBeenCalledWith([
+					expectedPromotedDeprecatedMarkdownChangelog,
+				])
+				expect(writeFiles).toHaveBeenCalledTimes(1)
+			})
+		})
+
+		describe("and two of five matching files are deprecated", () => {
+			beforeEach(async () => {
+				readMatchingFiles.mockImplementation(async () => [
+					promotableAsciidocChangelogs[1],
+					promotableDeprecatedMarkdownChangelog,
+					promotableMarkdownChangelogs[2],
+					promotablePackageJsonFiles[3],
+					promotableDeprecatedAsciidocChangelog,
+				])
+				actualExitCode = await mainProgram(args)
+			})
+
+			it("returns an exit code of 0", () => {
+				expect(actualExitCode).toBe(0)
+			})
+
+			it("displays two warnings", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printError).not.toHaveBeenCalled()
+				expect(printWarning).toHaveBeenNthCalledWith(
+					1,
+					`${promotableDeprecatedMarkdownChangelog.path} is not a supported filename and must be renamed to 'CHANGELOG.md' in Updraft v2.0.0.`,
+				)
+				expect(printWarning).toHaveBeenNthCalledWith(
+					2,
+					`${promotableDeprecatedAsciidocChangelog.path} is not a supported filename and must be renamed to 'CHANGELOG.adoc' in Updraft v2.0.0.`,
+				)
+				expect(printWarning).toHaveBeenCalledTimes(2)
+			})
+
+			it("saves the promoted files", () => {
+				expect(writeFiles).toHaveBeenCalledWith([
+					expectedPromotedAsciidocChangelogs[1],
+					expectedPromotedDeprecatedMarkdownChangelog,
+					expectedPromotedMarkdownChangelogs[2],
+					expectedPromotedPackageJsonFiles[3],
+					expectedPromotedDeprecatedAsciidocChangelog,
+				])
+				expect(writeFiles).toHaveBeenCalledTimes(1)
+			})
+		})
+
 		describe("and the only matching file is unsupported", () => {
 			beforeEach(async () => {
 				readMatchingFiles.mockImplementation(async () => [unsupportedFiles[0]])
@@ -731,6 +877,8 @@ describe.each`
 			})
 
 			it("displays an error", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenCalledWith(
 					`${unsupportedFiles[0].path} is not a supported file format.`,
 				)
@@ -758,6 +906,8 @@ describe.each`
 			})
 
 			it("displays an error", () => {
+				expect(printMessage).not.toHaveBeenCalled()
+				expect(printWarning).not.toHaveBeenCalled()
 				expect(printError).toHaveBeenCalledWith(
 					`${unsupportedFiles[1].path} is not a supported file format.`,
 				)
@@ -793,6 +943,8 @@ describe.each`
 				})
 
 				it("displays an error", () => {
+					expect(printMessage).not.toHaveBeenCalled()
+					expect(printWarning).not.toHaveBeenCalled()
 					expect(printError).toHaveBeenCalledWith(fullErrorMessage)
 					expect(printError).toHaveBeenCalledTimes(1)
 				})
@@ -832,6 +984,8 @@ describe.each`
 				})
 
 				it("displays an error", () => {
+					expect(printMessage).not.toHaveBeenCalled()
+					expect(printWarning).not.toHaveBeenCalled()
 					expect(printError).toHaveBeenCalledWith(fullErrorMessage)
 					expect(printError).toHaveBeenCalledTimes(1)
 				})

--- a/src/program/PromotionProgram/PromotionProgram.ts
+++ b/src/program/PromotionProgram/PromotionProgram.ts
@@ -77,13 +77,25 @@ export async function promotionProgram(
 function detectFileType(path: string): FileType {
 	const filename = path.split("/").at(-1) ?? ""
 
-	if (filename === "package.json") {
-		return "package-json"
+	switch (filename) {
+		case "CHANGELOG.adoc":
+			return "asciidoc-changelog"
+		case "CHANGELOG.md":
+			return "markdown-changelog"
+		case "package.json":
+			return "package-json"
 	}
+
 	if (filename.endsWith(".adoc")) {
+		printWarning(
+			`${filename} is not a supported filename and must be renamed to 'CHANGELOG.adoc' in Updraft v2.0.0.`,
+		)
 		return "asciidoc-changelog"
 	}
 	if (filename.endsWith(".md")) {
+		printWarning(
+			`${filename} is not a supported filename and must be renamed to 'CHANGELOG.md' in Updraft v2.0.0.`,
+		)
 		return "markdown-changelog"
 	}
 	throw new Error("is not a supported file format")

--- a/src/program/UsageInstructionsProgram/UsageInstructions.tests.ts
+++ b/src/program/UsageInstructionsProgram/UsageInstructions.tests.ts
@@ -10,8 +10,7 @@ it("is a list of program arguments and options", () => {
 		and bumping version numbers in package.json files.
 
 		Supported file formats:
-		  * AsciiDoc-based changelogs (*.adoc) in Keep a Changelog format.
-		  * Markdown-based changelogs (*.md) in Keep a Changelog format.
+		  * CHANGELOG.md and CHANGELOG.adoc in Keep a Changelog format.
 		  * package.json.
 
 		Options:

--- a/src/program/UsageInstructionsProgram/UsageInstructionsProgram.ts
+++ b/src/program/UsageInstructionsProgram/UsageInstructionsProgram.ts
@@ -12,8 +12,7 @@ This tool prepares a repository for an upcoming release by updating changelogs
 and bumping version numbers in package.json files.
 
 Supported file formats:
-  * AsciiDoc-based changelogs (*.adoc) in Keep a Changelog format.
-  * Markdown-based changelogs (*.md) in Keep a Changelog format.
+  * CHANGELOG.md and CHANGELOG.adoc in Keep a Changelog format.
   * package.json.
 
 Options:


### PR DESCRIPTION
`CHANGELOG.md` (or `CHANGELOG.adoc`) is the naming convention for
changelogs in the Keep a Changelog format.