### PR TITLE
Change the import alias prefix to `#`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -39,6 +39,16 @@
 					}
 				}
 			}
+		},
+		{
+			"include": ["vite.config.ts"],
+			"linter": {
+				"rules": {
+					"performance": {
+						"useTopLevelRegex": "off"
+					}
+				}
+			}
 		}
 	]
 }

--- a/src/CommandLineInterface.ts
+++ b/src/CommandLineInterface.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
 import process, { argv } from "node:process"
-import { updraftCliProgram } from "+program/UpdraftCliProgram"
+import { updraftCliProgram } from "#program/UpdraftCliProgram"
 
 updraftCliProgram(argv.slice(2)).then(process.exit)

--- a/src/GitHubActions.ts
+++ b/src/GitHubActions.ts
@@ -1,5 +1,5 @@
 import process from "node:process"
-import { getArgsFromActionInput } from "+adapters/ActionInput/ActionInput"
-import { updraftProgram } from "+program/UpdraftProgram"
+import { getArgsFromActionInput } from "#adapters/ActionInput/ActionInput"
+import { updraftProgram } from "#program/UpdraftProgram"
 
 updraftProgram(getArgsFromActionInput()).then(process.exit)

--- a/src/adapters/ActionInput/ActionInput.tests.ts
+++ b/src/adapters/ActionInput/ActionInput.tests.ts
@@ -1,5 +1,5 @@
-import { getArgsFromActionInput } from "+adapters/ActionInput/ActionInput"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { getArgsFromActionInput } from "#adapters/ActionInput/ActionInput"
 
 describe.each`
 	checkSequentialRelease | files                                                            | prereleaseFiles                                     | releaseFiles                                        | releaseVersion              | expectedArgs

--- a/src/adapters/ActionInput/ActionInput.ts
+++ b/src/adapters/ActionInput/ActionInput.ts
@@ -1,6 +1,6 @@
 import process from "node:process"
-import { notFalse } from "+utilities/IterableUtilities"
-import { toStringArray } from "+utilities/StringUtilities"
+import { notFalse } from "#utilities/IterableUtilities"
+import { toStringArray } from "#utilities/StringUtilities"
 
 export function getArgsFromActionInput(): Array<string> {
 	const checkSequentialRelease = getBooleanInput("check-sequential-release")

--- a/src/adapters/FileSystem/FileSystem.mock.ts
+++ b/src/adapters/FileSystem/FileSystem.mock.ts
@@ -1,8 +1,8 @@
-import type { ModuleMock } from "+utilities/ModuleMock"
 import { vi } from "vitest"
+import type { ModuleMock } from "#utilities/ModuleMock"
 
 export type FileSystemMock = ModuleMock<
-	typeof import("+adapters/FileSystem/FileSystem")
+	typeof import("#adapters/FileSystem/FileSystem")
 >
 
 export function injectFileSystemMock(): FileSystemMock {
@@ -11,6 +11,6 @@ export function injectFileSystemMock(): FileSystemMock {
 		writeFiles: vi.fn(),
 	}))
 
-	vi.mock("+adapters/FileSystem/FileSystem", () => mock)
+	vi.mock("#adapters/FileSystem/FileSystem", () => mock)
 	return mock
 }

--- a/src/adapters/FileSystem/FileSystem.ts
+++ b/src/adapters/FileSystem/FileSystem.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile } from "node:fs/promises"
-import type { File, Files } from "+adapters/FileSystem/File"
-import { assertError } from "+utilities/ErrorUtilities"
 import fg from "fast-glob"
+import type { File, Files } from "#adapters/FileSystem/File"
+import { assertError } from "#utilities/ErrorUtilities"
 
 export async function readMatchingFiles(
 	filePatterns: Array<string>,

--- a/src/adapters/Logger/Logger.mock.ts
+++ b/src/adapters/Logger/Logger.mock.ts
@@ -1,7 +1,7 @@
-import type { ModuleMock } from "+utilities/ModuleMock"
 import { vi } from "vitest"
+import type { ModuleMock } from "#utilities/ModuleMock"
 
-export type LoggerMock = ModuleMock<typeof import("+adapters/Logger/Logger")>
+export type LoggerMock = ModuleMock<typeof import("#adapters/Logger/Logger")>
 
 export function injectLoggerMock(): LoggerMock {
 	const mock = vi.hoisted<LoggerMock>(() => ({
@@ -10,6 +10,6 @@ export function injectLoggerMock(): LoggerMock {
 		printError: vi.fn(),
 	}))
 
-	vi.mock("+adapters/Logger/Logger", () => mock)
+	vi.mock("#adapters/Logger/Logger", () => mock)
 	return mock
 }

--- a/src/adapters/PackageJsonVersion/PackageJsonVersion.mock.ts
+++ b/src/adapters/PackageJsonVersion/PackageJsonVersion.mock.ts
@@ -1,8 +1,8 @@
-import type { ModuleMock } from "+utilities/ModuleMock"
 import { vi } from "vitest"
+import type { ModuleMock } from "#utilities/ModuleMock"
 
 export type PackageJsonVersionMock = ModuleMock<
-	typeof import("+adapters/PackageJsonVersion/PackageJsonVersion")
+	typeof import("#adapters/PackageJsonVersion/PackageJsonVersion")
 >
 
 export function injectPackageJsonVersionMock(): PackageJsonVersionMock {
@@ -10,6 +10,6 @@ export function injectPackageJsonVersionMock(): PackageJsonVersionMock {
 		packageJsonVersion: vi.fn(),
 	}))
 
-	vi.mock("+adapters/PackageJsonVersion/PackageJsonVersion", () => mock)
+	vi.mock("#adapters/PackageJsonVersion/PackageJsonVersion", () => mock)
 	return mock
 }

--- a/src/adapters/PackageJsonVersion/PackageJsonVersion.ts
+++ b/src/adapters/PackageJsonVersion/PackageJsonVersion.ts
@@ -1,5 +1,5 @@
-import type { SemanticVersionString } from "+utilities/types/SemanticVersionString"
-import { version } from "../../../package.json" assert { type: "json" }
+import type { SemanticVersionString } from "#utilities/types/SemanticVersionString"
+import { version } from "../../../package.json" with { type: "json" }
 
 export function packageJsonVersion(): SemanticVersionString {
 	return version as SemanticVersionString

--- a/src/adapters/Today/Today.mock.ts
+++ b/src/adapters/Today/Today.mock.ts
@@ -1,13 +1,13 @@
-import type { ModuleMock } from "+utilities/ModuleMock"
 import { vi } from "vitest"
+import type { ModuleMock } from "#utilities/ModuleMock"
 
-export type TodayMock = ModuleMock<typeof import("+adapters/Today/Today")>
+export type TodayMock = ModuleMock<typeof import("#adapters/Today/Today")>
 
 export function injectTodayMock(): TodayMock {
 	const mock = vi.hoisted<TodayMock>(() => ({
 		today: vi.fn(),
 	}))
 
-	vi.mock("+adapters/Today/Today", () => mock)
+	vi.mock("#adapters/Today/Today", () => mock)
 	return mock
 }

--- a/src/adapters/Today/Today.ts
+++ b/src/adapters/Today/Today.ts
@@ -1,4 +1,4 @@
-import type { DateString } from "+utilities/types/DateString"
+import type { DateString } from "#utilities/types/DateString"
 
 export function today(): DateString {
 	return new Date().toISOString().slice(0, "yyyy-mm-dd".length) as DateString

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { updraftCliProgram } from "+program/UpdraftCliProgram"
-export { updraftProgram } from "+program/UpdraftProgram"
+export { updraftCliProgram } from "#program/UpdraftCliProgram"
+export { updraftProgram } from "#program/UpdraftProgram"

--- a/src/program/InvalidConfigurationProgram/InvalidConfigurationProgram.tests.ts
+++ b/src/program/InvalidConfigurationProgram/InvalidConfigurationProgram.tests.ts
@@ -1,11 +1,11 @@
 // Mock injection imports must be at the top, separated from the regular imports by a blank line.
-import { injectFileSystemMock } from "+adapters/FileSystem/FileSystem.mock"
-import { injectLoggerMock } from "+adapters/Logger/Logger.mock"
+import { injectFileSystemMock } from "#adapters/FileSystem/FileSystem.mock"
+import { injectLoggerMock } from "#adapters/Logger/Logger.mock"
 
-import { updraftCliProgram } from "+program/UpdraftCliProgram"
-import type { ExitCode } from "+utilities/ErrorUtilities"
-import { dedent } from "+utilities/StringUtilities"
 import { beforeEach, describe, expect, it } from "vitest"
+import { updraftCliProgram } from "#program/UpdraftCliProgram"
+import type { ExitCode } from "#utilities/ErrorUtilities"
+import { dedent } from "#utilities/StringUtilities"
 
 const { printMessage, printWarning, printError } = injectLoggerMock()
 const { readMatchingFiles, writeFiles } = injectFileSystemMock()

--- a/src/program/InvalidConfigurationProgram/InvalidConfigurationProgram.ts
+++ b/src/program/InvalidConfigurationProgram/InvalidConfigurationProgram.ts
@@ -1,5 +1,5 @@
-import { printError } from "+adapters/Logger/Logger"
-import type { ExitCode } from "+utilities/ErrorUtilities"
+import { printError } from "#adapters/Logger/Logger"
+import type { ExitCode } from "#utilities/ErrorUtilities"
 
 export async function invalidConfigurationProgram(
 	errorMessage: string,

--- a/src/program/PromotionProgram/PromotionProgram.testdata.ts
+++ b/src/program/PromotionProgram/PromotionProgram.testdata.ts
@@ -1,7 +1,7 @@
-import type { File } from "+adapters/FileSystem/File"
-import { dedent } from "+utilities/StringUtilities"
-import type { DateString } from "+utilities/types/DateString"
-import type { SemanticVersionString } from "+utilities/types/SemanticVersionString"
+import type { File } from "#adapters/FileSystem/File"
+import { dedent } from "#utilities/StringUtilities"
+import type { DateString } from "#utilities/types/DateString"
+import type { SemanticVersionString } from "#utilities/types/SemanticVersionString"
 
 export function anEmptyAsciidocChangelog(
 	path: AsciidocChangelogFilepath,

--- a/src/program/PromotionProgram/PromotionProgram.tests.ts
+++ b/src/program/PromotionProgram/PromotionProgram.tests.ts
@@ -1,9 +1,10 @@
 // Mock injection imports must be at the top, separated from the regular imports by a blank line.
-import { injectFileSystemMock } from "+adapters/FileSystem/FileSystem.mock"
-import { injectLoggerMock } from "+adapters/Logger/Logger.mock"
-import { injectTodayMock } from "+adapters/Today/Today.mock"
+import { injectFileSystemMock } from "#adapters/FileSystem/FileSystem.mock"
+import { injectLoggerMock } from "#adapters/Logger/Logger.mock"
+import { injectTodayMock } from "#adapters/Today/Today.mock"
 
-import type { Files } from "+adapters/FileSystem/File"
+import { beforeEach, describe, expect, it } from "vitest"
+import type { Files } from "#adapters/FileSystem/File"
 import {
 	aNonPromotableAsciidocChangelog,
 	aNonPromotableMarkdownChangelog,
@@ -37,11 +38,10 @@ import {
 	anEmptyPackageJson,
 	anUnsupportedFileA,
 	anUnsupportedFileB,
-} from "+program/PromotionProgram/PromotionProgram.testdata"
-import { updraftCliProgram } from "+program/UpdraftCliProgram"
-import type { ExitCode } from "+utilities/ErrorUtilities"
-import type { DateString } from "+utilities/types/DateString"
-import { beforeEach, describe, expect, it } from "vitest"
+} from "#program/PromotionProgram/PromotionProgram.testdata"
+import { updraftCliProgram } from "#program/UpdraftCliProgram"
+import type { ExitCode } from "#utilities/ErrorUtilities"
+import type { DateString } from "#utilities/types/DateString"
 
 const { today } = injectTodayMock()
 const { printMessage, printWarning, printError } = injectLoggerMock()

--- a/src/program/PromotionProgram/PromotionProgram.ts
+++ b/src/program/PromotionProgram/PromotionProgram.ts
@@ -1,17 +1,17 @@
-import type { File } from "+adapters/FileSystem/File"
-import { readMatchingFiles, writeFiles } from "+adapters/FileSystem/FileSystem"
-import { printError, printMessage, printWarning } from "+adapters/Logger/Logger"
-import { today } from "+adapters/Today/Today"
-import { promoteAsciidocChangelog } from "+promoters/PromoteAsciidocChangelog/PromoteAsciidocChangelog"
-import { promoteMarkdownChangelog } from "+promoters/PromoteMarkdownChangelog/PromoteMarkdownChangelog"
-import { promotePackageJson } from "+promoters/PromotePackageJson/PromotePackageJson"
-import { type ExitCode, assertError } from "+utilities/ErrorUtilities"
-import { isFulfilled, isRejected } from "+utilities/PromiseUtilities"
-import type { Release, ReleaseCheck } from "+utilities/types/Release"
+import type { File } from "#adapters/FileSystem/File"
+import { readMatchingFiles, writeFiles } from "#adapters/FileSystem/FileSystem"
+import { printError, printMessage, printWarning } from "#adapters/Logger/Logger"
+import { today } from "#adapters/Today/Today"
+import { promoteAsciidocChangelog } from "#promoters/PromoteAsciidocChangelog/PromoteAsciidocChangelog"
+import { promoteMarkdownChangelog } from "#promoters/PromoteMarkdownChangelog/PromoteMarkdownChangelog"
+import { promotePackageJson } from "#promoters/PromotePackageJson/PromotePackageJson"
+import { type ExitCode, assertError } from "#utilities/ErrorUtilities"
+import { isFulfilled, isRejected } from "#utilities/PromiseUtilities"
+import type { Release, ReleaseCheck } from "#utilities/types/Release"
 import {
 	type SemanticVersionString,
 	isPrerelease,
-} from "+utilities/types/SemanticVersionString"
+} from "#utilities/types/SemanticVersionString"
 
 const promoters: Record<FileType, Promoter> = {
 	"asciidoc-changelog": promoteAsciidocChangelog,

--- a/src/program/ToolVersionProgram/ToolVersionProgram.tests.ts
+++ b/src/program/ToolVersionProgram/ToolVersionProgram.tests.ts
@@ -1,12 +1,12 @@
 // Mock injection imports must be at the top, separated from the regular imports by a blank line.
-import { injectFileSystemMock } from "+adapters/FileSystem/FileSystem.mock"
-import { injectLoggerMock } from "+adapters/Logger/Logger.mock"
-import { injectPackageJsonVersionMock } from "+adapters/PackageJsonVersion/PackageJsonVersion.mock"
+import { injectFileSystemMock } from "#adapters/FileSystem/FileSystem.mock"
+import { injectLoggerMock } from "#adapters/Logger/Logger.mock"
+import { injectPackageJsonVersionMock } from "#adapters/PackageJsonVersion/PackageJsonVersion.mock"
 
-import { updraftCliProgram } from "+program/UpdraftCliProgram"
-import type { ExitCode } from "+utilities/ErrorUtilities"
-import type { SemanticVersionString } from "+utilities/types/SemanticVersionString"
 import { beforeEach, describe, expect, it } from "vitest"
+import { updraftCliProgram } from "#program/UpdraftCliProgram"
+import type { ExitCode } from "#utilities/ErrorUtilities"
+import type { SemanticVersionString } from "#utilities/types/SemanticVersionString"
 
 const { packageJsonVersion } = injectPackageJsonVersionMock()
 const { printMessage } = injectLoggerMock()

--- a/src/program/ToolVersionProgram/ToolVersionProgram.ts
+++ b/src/program/ToolVersionProgram/ToolVersionProgram.ts
@@ -1,6 +1,6 @@
-import { printMessage } from "+adapters/Logger/Logger"
-import { packageJsonVersion } from "+adapters/PackageJsonVersion/PackageJsonVersion"
-import type { ExitCode } from "+utilities/ErrorUtilities"
+import { printMessage } from "#adapters/Logger/Logger"
+import { packageJsonVersion } from "#adapters/PackageJsonVersion/PackageJsonVersion"
+import type { ExitCode } from "#utilities/ErrorUtilities"
 
 export async function toolVersionProgram(): Promise<ExitCode> {
 	printMessage(packageJsonVersion())

--- a/src/program/UpdraftCliProgram.ts
+++ b/src/program/UpdraftCliProgram.ts
@@ -1,7 +1,7 @@
-import { toolVersionProgram } from "+program/ToolVersionProgram/ToolVersionProgram"
-import { updraftProgram } from "+program/UpdraftProgram"
-import { usageInstructionsProgram } from "+program/UsageInstructionsProgram/UsageInstructionsProgram"
-import type { ExitCode } from "+utilities/ErrorUtilities"
+import { toolVersionProgram } from "#program/ToolVersionProgram/ToolVersionProgram"
+import { updraftProgram } from "#program/UpdraftProgram"
+import { usageInstructionsProgram } from "#program/UsageInstructionsProgram/UsageInstructionsProgram"
+import type { ExitCode } from "#utilities/ErrorUtilities"
 
 export async function updraftCliProgram(
 	args: Array<string>,

--- a/src/program/UpdraftProgram.ts
+++ b/src/program/UpdraftProgram.ts
@@ -1,13 +1,13 @@
-import { invalidConfigurationProgram } from "+program/InvalidConfigurationProgram/InvalidConfigurationProgram"
-import { promotionProgram } from "+program/PromotionProgram/PromotionProgram"
-import { defineOptions, parseArgs } from "+utilities/ArgsUtilities"
-import { type ExitCode, assertError } from "+utilities/ErrorUtilities"
-import { notNullish } from "+utilities/IterableUtilities"
-import type { ReleaseCheck } from "+utilities/types/Release"
+import { invalidConfigurationProgram } from "#program/InvalidConfigurationProgram/InvalidConfigurationProgram"
+import { promotionProgram } from "#program/PromotionProgram/PromotionProgram"
+import { defineOptions, parseArgs } from "#utilities/ArgsUtilities"
+import { type ExitCode, assertError } from "#utilities/ErrorUtilities"
+import { notNullish } from "#utilities/IterableUtilities"
+import type { ReleaseCheck } from "#utilities/types/Release"
 import {
 	extractSemanticVersionString,
 	isPrerelease,
-} from "+utilities/types/SemanticVersionString"
+} from "#utilities/types/SemanticVersionString"
 
 export async function updraftProgram(
 	args: Array<string>,

--- a/src/program/UsageInstructionsProgram/UsageInstructions.tests.ts
+++ b/src/program/UsageInstructionsProgram/UsageInstructions.tests.ts
@@ -1,7 +1,7 @@
-import { getUsageInstructions } from "+program/UsageInstructionsProgram/UsageInstructionsProgram"
-import { dedent } from "+utilities/StringUtilities"
 import { bold, cyan, yellow } from "ansis"
 import { expect, it } from "vitest"
+import { getUsageInstructions } from "#program/UsageInstructionsProgram/UsageInstructionsProgram"
+import { dedent } from "#utilities/StringUtilities"
 
 it("is a list of program arguments and options", () => {
 	expect(getUsageInstructions()).toBe(dedent`

--- a/src/program/UsageInstructionsProgram/UsageInstructionsProgram.tests.ts
+++ b/src/program/UsageInstructionsProgram/UsageInstructionsProgram.tests.ts
@@ -1,11 +1,11 @@
 // Mock injection imports must be at the top, separated from the regular imports by a blank line.
-import { injectFileSystemMock } from "+adapters/FileSystem/FileSystem.mock"
-import { injectLoggerMock } from "+adapters/Logger/Logger.mock"
+import { injectFileSystemMock } from "#adapters/FileSystem/FileSystem.mock"
+import { injectLoggerMock } from "#adapters/Logger/Logger.mock"
 
-import { updraftCliProgram } from "+program/UpdraftCliProgram"
-import { getUsageInstructions } from "+program/UsageInstructionsProgram/UsageInstructionsProgram"
-import type { ExitCode } from "+utilities/ErrorUtilities"
 import { beforeEach, describe, expect, it } from "vitest"
+import { updraftCliProgram } from "#program/UpdraftCliProgram"
+import { getUsageInstructions } from "#program/UsageInstructionsProgram/UsageInstructionsProgram"
+import type { ExitCode } from "#utilities/ErrorUtilities"
 
 const { printMessage } = injectLoggerMock()
 const { readMatchingFiles, writeFiles } = injectFileSystemMock()

--- a/src/program/UsageInstructionsProgram/UsageInstructionsProgram.ts
+++ b/src/program/UsageInstructionsProgram/UsageInstructionsProgram.ts
@@ -1,6 +1,6 @@
-import { printMessage } from "+adapters/Logger/Logger"
-import type { ExitCode } from "+utilities/ErrorUtilities"
 import { bold, cyan, yellow } from "ansis"
+import { printMessage } from "#adapters/Logger/Logger"
+import type { ExitCode } from "#utilities/ErrorUtilities"
 
 export async function usageInstructionsProgram(): Promise<ExitCode> {
 	printMessage(getUsageInstructions())

--- a/src/promoters/PromoteAsciidocChangelog/PromoteAsciidocChangelog.tests.ts
+++ b/src/promoters/PromoteAsciidocChangelog/PromoteAsciidocChangelog.tests.ts
@@ -1,9 +1,9 @@
-import { promoteAsciidocChangelog } from "+promoters/PromoteAsciidocChangelog/PromoteAsciidocChangelog"
-import { dedent } from "+utilities/StringUtilities"
-import type { DateString } from "+utilities/types/DateString"
-import type { Release } from "+utilities/types/Release"
-import type { SemanticVersionString } from "+utilities/types/SemanticVersionString"
 import { describe, expect, it } from "vitest"
+import { promoteAsciidocChangelog } from "#promoters/PromoteAsciidocChangelog/PromoteAsciidocChangelog"
+import { dedent } from "#utilities/StringUtilities"
+import type { DateString } from "#utilities/types/DateString"
+import type { Release } from "#utilities/types/Release"
+import type { SemanticVersionString } from "#utilities/types/SemanticVersionString"
 
 describe.each`
 	releaseVersion      | releaseDate     | githubRepositoryUrl

--- a/src/promoters/PromoteAsciidocChangelog/PromoteAsciidocChangelog.ts
+++ b/src/promoters/PromoteAsciidocChangelog/PromoteAsciidocChangelog.ts
@@ -1,9 +1,9 @@
-import { notNullish } from "+utilities/IterableUtilities"
-import type { Release } from "+utilities/types/Release"
+import { notNullish } from "#utilities/IterableUtilities"
+import type { Release } from "#utilities/types/Release"
 import {
 	checkSequentialRelease,
 	extractSemanticVersionString,
-} from "+utilities/types/SemanticVersionString"
+} from "#utilities/types/SemanticVersionString"
 
 // Matches an unreleased section, including the heading and the body, which
 // spans the characters after the heading until the next '==' heading or until

--- a/src/promoters/PromoteMarkdownChangelog/PromoteMarkdownChangelog.tests.ts
+++ b/src/promoters/PromoteMarkdownChangelog/PromoteMarkdownChangelog.tests.ts
@@ -1,9 +1,9 @@
-import { promoteMarkdownChangelog } from "+promoters/PromoteMarkdownChangelog/PromoteMarkdownChangelog"
-import { dedent } from "+utilities/StringUtilities"
-import type { DateString } from "+utilities/types/DateString"
-import type { Release } from "+utilities/types/Release"
-import type { SemanticVersionString } from "+utilities/types/SemanticVersionString"
 import { describe, expect, it } from "vitest"
+import { promoteMarkdownChangelog } from "#promoters/PromoteMarkdownChangelog/PromoteMarkdownChangelog"
+import { dedent } from "#utilities/StringUtilities"
+import type { DateString } from "#utilities/types/DateString"
+import type { Release } from "#utilities/types/Release"
+import type { SemanticVersionString } from "#utilities/types/SemanticVersionString"
 
 describe.each`
 	releaseVersion      | releaseDate     | githubRepositoryUrl

--- a/src/promoters/PromoteMarkdownChangelog/PromoteMarkdownChangelog.ts
+++ b/src/promoters/PromoteMarkdownChangelog/PromoteMarkdownChangelog.ts
@@ -1,9 +1,9 @@
-import { notNullish } from "+utilities/IterableUtilities"
-import type { Release } from "+utilities/types/Release"
+import { notNullish } from "#utilities/IterableUtilities"
+import type { Release } from "#utilities/types/Release"
 import {
 	checkSequentialRelease,
 	extractSemanticVersionString,
-} from "+utilities/types/SemanticVersionString"
+} from "#utilities/types/SemanticVersionString"
 
 // Matches an unreleased section, including the heading and the body, which
 // spans the characters after the heading until the next '##' heading or until

--- a/src/promoters/PromotePackageJson/PromotePackageJson.tests.ts
+++ b/src/promoters/PromotePackageJson/PromotePackageJson.tests.ts
@@ -1,8 +1,8 @@
-import { promotePackageJson } from "+promoters/PromotePackageJson/PromotePackageJson"
-import { dedent } from "+utilities/StringUtilities"
-import type { Release } from "+utilities/types/Release"
-import type { SemanticVersionString } from "+utilities/types/SemanticVersionString"
 import { describe, expect, it } from "vitest"
+import { promotePackageJson } from "#promoters/PromotePackageJson/PromotePackageJson"
+import { dedent } from "#utilities/StringUtilities"
+import type { Release } from "#utilities/types/Release"
+import type { SemanticVersionString } from "#utilities/types/SemanticVersionString"
 
 describe("when the package.json file does not have a 'version' field", () => {
 	const originalContent = dedent`

--- a/src/promoters/PromotePackageJson/PromotePackageJson.ts
+++ b/src/promoters/PromotePackageJson/PromotePackageJson.ts
@@ -1,9 +1,9 @@
-import { assertNotNullish } from "+utilities/Assertions"
-import type { Release } from "+utilities/types/Release"
+import { assertNotNullish } from "#utilities/Assertions"
+import type { Release } from "#utilities/types/Release"
 import {
 	checkSequentialRelease,
 	extractSemanticVersionString,
-} from "+utilities/types/SemanticVersionString"
+} from "#utilities/types/SemanticVersionString"
 
 // Matches the `version` field.
 const versionFieldRegex = /"version":(?<whitespace>\s*)"(?<version>[^"]+)"/u

--- a/src/utilities/ArgsUtilities.ts
+++ b/src/utilities/ArgsUtilities.ts
@@ -1,4 +1,4 @@
-import { pluralise } from "+utilities/StringUtilities"
+import { pluralise } from "#utilities/StringUtilities"
 
 export function parseArgs<Option extends string>(
 	schema: OptionSchema<Option>,

--- a/src/utilities/StringUtilities.tests.ts
+++ b/src/utilities/StringUtilities.tests.ts
@@ -1,5 +1,5 @@
-import { dedent } from "+utilities/StringUtilities"
 import { describe, expect, it } from "vitest"
+import { dedent } from "#utilities/StringUtilities"
 
 describe("dedenting an empty string", () => {
 	const result = dedent``

--- a/src/utilities/StringUtilities.ts
+++ b/src/utilities/StringUtilities.ts
@@ -1,4 +1,4 @@
-import { assertNotNullish } from "+utilities/Assertions"
+import { assertNotNullish } from "#utilities/Assertions"
 
 const leadingAndTrailingLinesRegex = /^\n+|\n+$/gu
 

--- a/src/utilities/types/ComparableSemanticVersionString.tests.ts
+++ b/src/utilities/types/ComparableSemanticVersionString.tests.ts
@@ -1,10 +1,10 @@
+import { beforeEach, describe, expect, it } from "vitest"
 import {
 	type ComparableSemanticVersionString,
 	isSequentialUpgrade,
 	toComparableSemanticVersionString,
-} from "+utilities/types/ComparableSemanticVersionString"
-import type { SemanticVersionString } from "+utilities/types/SemanticVersionString"
-import { beforeEach, describe, expect, it } from "vitest"
+} from "#utilities/types/ComparableSemanticVersionString"
+import type { SemanticVersionString } from "#utilities/types/SemanticVersionString"
 
 describe.each`
 	version                          | expectedMajor | expectedMinor | expectedPatch | expectedPrereleaseLabel | expectedPrereleaseDelimiter | expectedPrereleaseIncrement | expectedBuild

--- a/src/utilities/types/ComparableSemanticVersionString.ts
+++ b/src/utilities/types/ComparableSemanticVersionString.ts
@@ -1,8 +1,8 @@
-import { assertNotNullish } from "+utilities/Assertions"
+import { assertNotNullish } from "#utilities/Assertions"
 import {
 	type SemanticVersionString,
 	semanticVersionRegex,
-} from "+utilities/types/SemanticVersionString"
+} from "#utilities/types/SemanticVersionString"
 
 export type ComparableSemanticVersionString = {
 	major: number

--- a/src/utilities/types/Release.ts
+++ b/src/utilities/types/Release.ts
@@ -1,5 +1,5 @@
-import type { DateString } from "+utilities/types/DateString"
-import type { SemanticVersionString } from "+utilities/types/SemanticVersionString"
+import type { DateString } from "#utilities/types/DateString"
+import type { SemanticVersionString } from "#utilities/types/SemanticVersionString"
 
 export type Release = {
 	checks: Array<ReleaseCheck>

--- a/src/utilities/types/SemanticVersionString.tests.ts
+++ b/src/utilities/types/SemanticVersionString.tests.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "vitest"
 import {
 	type SemanticVersionString,
 	extractSemanticVersionString,
 	isPrerelease,
-} from "+utilities/types/SemanticVersionString"
-import { describe, expect, it } from "vitest"
+} from "#utilities/types/SemanticVersionString"
 
 describe.each`
 	input                               | expectedSemanticVersionString

--- a/src/utilities/types/SemanticVersionString.ts
+++ b/src/utilities/types/SemanticVersionString.ts
@@ -1,5 +1,5 @@
-import { isNonEmptyArray } from "+utilities/Arrays"
-import { isSequentialUpgrade } from "+utilities/types/ComparableSemanticVersionString"
+import { isNonEmptyArray } from "#utilities/Arrays"
+import { isSequentialUpgrade } from "#utilities/types/ComparableSemanticVersionString"
 
 export type SemanticVersionString =
 	| `${number}.${number}.${number}`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,10 +9,10 @@
 		"incremental": true,
 		"libReplacement": false,
 		"paths": {
-			"+adapters/*": ["./src/adapters/*"],
-			"+promoters/*": ["./src/promoters/*"],
-			"+program/*": ["./src/program/*"],
-			"+utilities/*": ["./src/utilities/*"]
+			"#adapters/*": ["./src/adapters/*"],
+			"#promoters/*": ["./src/promoters/*"],
+			"#program/*": ["./src/program/*"],
+			"#utilities/*": ["./src/utilities/*"]
 		},
 		"tsBuildInfoFile": "node_modules/.cache/typescript/.tsbuildinfo"
 	},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import { copyFile } from "node:fs/promises"
 import { builtinModules } from "node:module"
 import { basename, join as joinPath, resolve as resolvePath } from "node:path"
-import process from "node:process"
+import { env } from "node:process"
 import { fileURLToPath } from "node:url"
 import type { Plugin } from "vite"
 import {
@@ -9,8 +9,7 @@ import {
 	defineConfig,
 	mergeConfig,
 } from "vitest/config"
-import packageJson from "./package.json" assert { type: "json" }
-import tsconfigJson from "./tsconfig.json" assert { type: "json" }
+import packageJson from "./package.json" with { type: "json" }
 
 export default defineConfig(() => {
 	const npmDependencies = Object.keys(packageJson.dependencies)
@@ -32,35 +31,33 @@ export default defineConfig(() => {
 				},
 			},
 		},
-		cacheDir: inProjectDirectory("node_modules/.cache/"),
+		cacheDir: path("node_modules/.cache/"),
 		plugins: [],
 		resolve: {
-			alias: tsconfigPathAliases(),
+			alias: [{ find: /^#(.+)/, replacement: path("src/$1") }],
 		},
 		test: {
 			coverage: {
 				include: ["src/**/*.ts"],
 				exclude: ["src/**/*.tests.ts"],
 				provider: "v8" as const,
-				reportsDirectory: inProjectDirectory(
-					"node_modules/.cache/vitest/coverage/",
-				),
+				reportsDirectory: path("node_modules/.cache/vitest/coverage/"),
 			},
 			include: ["src/**/*.tests.ts"],
 			mockReset: true,
 		},
 	}
 
-	switch (process.env.MODULE) {
+	switch (env.MODULE) {
 		case "cli": {
 			return mergeConfig(baseConfiguration, {
 				build: {
 					rollupOptions: {
-						external: [...allDependencies, "+program/UpdraftCliProgram"],
-						input: inProjectDirectory("src/CommandLineInterface.ts"),
+						external: [...allDependencies, "#program/UpdraftCliProgram"],
+						input: path("src/CommandLineInterface.ts"),
 						output: {
 							paths: {
-								"+program/UpdraftCliProgram": "../lib/index.js",
+								"#program/UpdraftCliProgram": "../lib/index.js",
 							},
 						},
 					},
@@ -72,7 +69,7 @@ export default defineConfig(() => {
 				build: {
 					rollupOptions: {
 						external: nodeDependencies,
-						input: inProjectDirectory("src/GitHubActions.ts"),
+						input: path("src/GitHubActions.ts"),
 					},
 				},
 			} satisfies ViteConfig)
@@ -82,11 +79,11 @@ export default defineConfig(() => {
 				build: {
 					rollupOptions: {
 						external: allDependencies, // Prevents inlining the dependencies into the build artifacts.
-						input: inProjectDirectory("src/index.ts"),
+						input: path("src/index.ts"),
 						preserveEntrySignatures: "allow-extension" as const, // Preserves the exports of `index.ts`.
 					},
 				},
-				plugins: [copyFilePlugin(inProjectDirectory("src/index.d.ts"))],
+				plugins: [copyFilePlugin(path("src/index.d.ts"))],
 			} satisfies ViteConfig)
 		}
 	}
@@ -94,34 +91,12 @@ export default defineConfig(() => {
 	return baseConfiguration
 })
 
-function tsconfigPathAliases(): Record<string, string> {
-	return Object.fromEntries(
-		Object.entries(tsconfigJson.compilerOptions.paths).map((entry) => {
-			assertSinglePath(entry)
-			const [alias, [path]] = entry
-			return [
-				alias.slice(0, -"/*".length),
-				inProjectDirectory(path.slice(0, -"/*".length)),
-			]
-		}),
-	)
-}
-
-function assertSinglePath(
-	entry: [alias: string, paths: Array<string>],
-): asserts entry is [alias: string, paths: [string]] {
-	const [alias, paths] = entry
-	if (paths.length !== 1) {
-		throw new Error(
-			`Path alias '${alias}' in 'tsconfig.json' must specify exactly one path, but has ${paths.length} paths`,
-		)
-	}
-}
-
-const projectDirectory = joinPath(fileURLToPath(import.meta.url), "..")
-
-function inProjectDirectory(relativePath: string): string {
-	return resolvePath(projectDirectory, relativePath)
+/**
+ * Resolves a path relative to the project directory.
+ */
+function path(pathname: string): string {
+	const projectDirectory = joinPath(fileURLToPath(import.meta.url), "..")
+	return resolvePath(projectDirectory, pathname)
 }
 
 function copyFilePlugin(sourcePathname: string): Plugin {


### PR DESCRIPTION
It replaces the `+` prefix. It is compatible with the official Node.js naming convention for subpath imports, and it enables import sorting in Biome 2 in a future commit.